### PR TITLE
chore: migrate to publications

### DIFF
--- a/articles/blockchain-symbol-angular-1st-symbol-sdk.md
+++ b/articles/blockchain-symbol-angular-1st-symbol-sdk.md
@@ -4,6 +4,7 @@ emoji: "⛓"
 type: "tech" # tech: 技術記事 / idea: アイデア
 topics: ["blockchain", "symbol", "angular", "typescript", "rxjs"]
 published: true
+publication_name: "nemtus_official"
 ---
 
 # Angularでsymbol-sdkを使うための環境構築

--- a/articles/blockchain-symbol-react-1st-symbol-sdk.md
+++ b/articles/blockchain-symbol-react-1st-symbol-sdk.md
@@ -4,6 +4,7 @@ emoji: "⛓"
 type: "tech" # tech: 技術記事 / idea: アイデア
 topics: ["blockchain", "symbol", "react", "typescript", "rxjs"]
 published: true
+publication_name: "nemtus_official"
 ---
 
 

--- a/articles/blockchian-symbol-ionic-vue-1.md
+++ b/articles/blockchian-symbol-ionic-vue-1.md
@@ -4,6 +4,7 @@ emoji: "⛓"
 type: "tech" # tech: 技術記事 / idea: アイデア
 topics: ["blockchain", "symbol", "ionic", "typescript", "vue"]
 published: true
+publication_name: "nemtus_official"
 ---
 
 # Ionic(vue)でSymbolモバイルアプリを作ってみる その1

--- a/articles/nemtus-symbol-sdk-openapi-generator-typescript.md
+++ b/articles/nemtus-symbol-sdk-openapi-generator-typescript.md
@@ -4,6 +4,7 @@ emoji: "⛓"
 type: "tech" # tech: 技術記事 / idea: アイデア
 topics: ["blockchain", "symbol", "openapigenerator", "typescript", "npm"]
 published: true
+publication_name: "nemtus_official"
 ---
 
 # SymbolブロックチェーンのTypeScript向けREST API clientコードの自動生成とDual package(CommonJS/ES Modules)＆CDN対応済npmパッケージ公開の紹介

--- a/articles/nemtus-symbol-sdk-typescript.md
+++ b/articles/nemtus-symbol-sdk-typescript.md
@@ -4,6 +4,7 @@ emoji: "⛓"
 type: "tech" # tech: 技術記事 / idea: アイデア
 topics: ["blockchain", "symbol", "typescript", "javascript", "npm"]
 published: true
+publication_name: "nemtus_official"
 ---
 
 # SymbolブロックチェーンのJavaScript向け新公式SDKのTypeScript化及びトランザクション送信サンプルコードの紹介

--- a/articles/symbol-aggregate-bonded-transaction.md
+++ b/articles/symbol-aggregate-bonded-transaction.md
@@ -4,6 +4,7 @@ emoji: "⛓"
 type: "tech" # tech: 技術記事 / idea: アイデア
 topics: ["blockchain", "symbol", "typescript", "javascript", "npm"]
 published: true
+publication_name: "nemtus_official"
 ---
 
 ## 要約


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new metadata field, `publication_name`, to several articles, enhancing their attribution and context by indicating they are published under "nemtus_official."
  
- **Bug Fixes**
	- No specific bug fixes were included in this release. 

- **Documentation**
	- Updated article metadata to improve categorization and discoverability within the publication context.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->